### PR TITLE
Fixed `rotate()` method for using TRY_HARDER

### DIFF
--- a/src/HTMLCanvasElementLuminanceSource.ts
+++ b/src/HTMLCanvasElementLuminanceSource.ts
@@ -144,8 +144,8 @@ export class HTMLCanvasElementLuminanceSource extends LuminanceSource {
 
             const tempCanvasElement = this.canvas.ownerDocument.createElement('canvas');
 
-            tempCanvasElement.style.width = `${this.canvas.width}px`;
-            tempCanvasElement.style.height = `${this.canvas.height}px`;
+            tempCanvasElement.width = this.canvas.width;
+            tempCanvasElement.height = this.canvas.height;
 
             this.tempCanvasElement = tempCanvasElement;
         }
@@ -167,8 +167,19 @@ export class HTMLCanvasElementLuminanceSource extends LuminanceSource {
             throw new Error('Could not get the current canvas context.');
         }
 
-        tempContext.rotate(angle * HTMLCanvasElementLuminanceSource.DEGREE_TO_RADIANS);
-        tempContext.drawImage(this.canvas, 0, 0);
+        // Calculate and set new dimensions for temp canvas
+        const angleRadians = angle * HTMLCanvasElementLuminanceSource.DEGREE_TO_RADIANS;
+        const width = tempCanvasElement.width;
+        const height = tempCanvasElement.height;
+        const newWidth = Math.ceil( Math.abs(Math.cos(angleRadians)) * width + Math.abs(Math.sin(angleRadians)) * height );
+        const newHeight = Math.ceil( Math.abs(Math.sin(angleRadians)) * width + Math.abs(Math.cos(angleRadians)) * height );
+        tempCanvasElement.width = newWidth;
+        tempCanvasElement.height = newHeight;
+
+        // Draw at center of temp canvas to prevent clipping of image data
+        tempContext.translate(newWidth / 2, newHeight / 2);
+        tempContext.rotate(angleRadians);
+        tempContext.drawImage(this.canvas, width / -2, height / -2);
 
         this.buffer = HTMLCanvasElementLuminanceSource.makeBufferFromCanvasImageData(tempCanvasElement);
 

--- a/src/HTMLCanvasElementLuminanceSource.ts
+++ b/src/HTMLCanvasElementLuminanceSource.ts
@@ -169,8 +169,8 @@ export class HTMLCanvasElementLuminanceSource extends LuminanceSource {
 
         // Calculate and set new dimensions for temp canvas
         const angleRadians = angle * HTMLCanvasElementLuminanceSource.DEGREE_TO_RADIANS;
-        const width = tempCanvasElement.width;
-        const height = tempCanvasElement.height;
+        const width = this.canvas.width;
+        const height = this.canvas.height;
         const newWidth = Math.ceil( Math.abs(Math.cos(angleRadians)) * width + Math.abs(Math.sin(angleRadians)) * height );
         const newHeight = Math.ceil( Math.abs(Math.sin(angleRadians)) * width + Math.abs(Math.cos(angleRadians)) * height );
         tempCanvasElement.width = newWidth;


### PR DESCRIPTION
**Problem:**
The rotated image was rotated off the canvas, so the image data gathered after was actually an empty (full white) image. And thus using TRY_HARDER wasn't going to find a barcode in the rotated image anyway.

**Solution:**
1) Calculate the needed size for the temporary canvas to fit the entire rotated image.
2) Draw the rotated image at the center of the temporary canvas, so all image data is preserved.