### PR TITLE
Fix 'undefined globalThis' on older browsers

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,7 +5,7 @@ export default {
   plugins: [
     resolve(),
   ],
-  context: '(globalThis || global || self || window || undefined)',
+  context: '(global || self || globalThis || window || undefined)',
   output: {
     format: 'umd',
     name: 'ZXingBrowser',


### PR DESCRIPTION
This is in reference to issue #18
(but also issue #382 on the zxing-js/library repo)

In browsers older than 2 years (e.g. Chrome v.71) globalThis is not defined.
This fixes an error when used in the WebView of the Android 7.x applications.

Moving "globalThis" after "self" will allow the library to work also on Android 7.x