### PR TITLE
resolved browser entrypoint issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
     "module": "./esm/index.js",
     "typings": "./esm/index.d.ts",
     "esnext": "./es2015/index.js",
-    "browser": "./umd/zxing-browser.js",
-    "browser:min": "./umd/zxing-browser.min.js",
+    "unpkg": "./umd/zxing-browser.min.js",
     "scripts": {
         "clean": "./node_modules/.bin/shx rm -rf umd esm esm5",
         "build": "yarn clean && yarn build:es2015 && yarn build:esm && yarn build:cjs && yarn build:umd && yarn build:umd:min && yarn build:copy",


### PR DESCRIPTION
The old `browser` entry point was causing some confusion to module bundlers which didn't prefer bundling from the actual `module` entry point. The old `browser` entry point was removed since all entrypoint are meant to work on browsers and so on the bundlers can make better choices. 

A `unpkg` entry point was added since UNPKG makes a big part in the usage of this lib.

Reference content about package.json entry points: 

- https://docs.npmjs.com/cli/v7/configuring-npm/package-json
- https://areknawo.com/whats-what-package-json-cheatsheet/

---

### Many thanks to [Timly](https://timly.com) for sponsoring this PR. 💙🐇
