### PR TITLE
Init tempCanvasElement to null

### DIFF
--- a/src/common/HTMLCanvasElementLuminanceSource.ts
+++ b/src/common/HTMLCanvasElementLuminanceSource.ts
@@ -43,7 +43,7 @@ export class HTMLCanvasElementLuminanceSource extends LuminanceSource {
 
   private buffer: Uint8ClampedArray;
 
-  private tempCanvasElement?: HTMLCanvasElement;
+  private tempCanvasElement?: HTMLCanvasElement = null;
 
   public constructor(private canvas: HTMLCanvasElement) {
     super(canvas.width, canvas.height);


### PR DESCRIPTION
Related to this issue https://github.com/zxing-js/browser/issues/74, it seems that `this.tempCanvasElement` is not initialized, resulting in an `undefined` value.

When it's compared to null in `getTempCanvasElement`, it's not initialized for the first time and `rotate()` returns the error: `Could not create a Canvas element`.