### PR TITLE
Fix a typo "BrowserMultiFormatReader"

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ That's it for now.
 - `BrowserCodeReader` (abstract, needs to be extend for use)
 - `BrowserDatamatrixCodeReader`
 - `BrowserMultiFormatOneDReader`
-- `BrowserMultiFormatCodeReader` (2D + 1D)
+- `BrowserMultiFormatReader` (2D + 1D)
 - `BrowserPDF417CodeReader`
 - `BrowserQRCodeReader`
 


### PR DESCRIPTION
There was a typo in the readme. `BrowserMultiFormatReader` is the correct class (`BrowserMultiFormatCodeReader` doesn't exist).