### PR TITLE
fix: make stop function awaitable

### DIFF
--- a/src/readers/BrowserCodeReader.ts
+++ b/src/readers/BrowserCodeReader.ts
@@ -703,7 +703,7 @@ export class BrowserCodeReader {
     const controls: IScannerControls = {
       ...originalControls,
 
-      stop() {
+      async stop() {
         originalControls.stop();
       },
 
@@ -750,9 +750,9 @@ export class BrowserCodeReader {
 
       controls.switchTorch = switchTorch;
 
-      const stop = () => {
+      const stop = async () => {
         originalControls.stop();
-        switchTorch(false);
+        await switchTorch(false);
       };
 
       controls.stop = stop;


### PR DESCRIPTION
Link to [issue-64](https://github.com/zxing-js/browser/issues/67)

The `stop()` method of `IScannerControls` isn't awaitable and, in some case , the method emit DOMException due of the async method `switchTorch()`. And If we can't await this method isn't possible to properly catch the Exception.