### PR TITLE
fix: Add missing await

### DIFF
--- a/src/readers/BrowserCodeReader.ts
+++ b/src/readers/BrowserCodeReader.ts
@@ -752,7 +752,7 @@ export class BrowserCodeReader {
 
       const stop = () => {
         originalControls.stop();
-        switchTorch(false);
+        await switchTorch(false);
       };
 
       controls.stop = stop;


### PR DESCRIPTION
## controls.stop

This line is missing an await when calling `switchTorch`, so if it fails theres no way to capture the error in a try catch.

https://github.com/zxing-js/browser/blob/9e0ef5e4a661a5989a9b4a97117a20b1fcd4527d/src/readers/BrowserCodeReader.ts#L755

![image](https://github.com/zxing-js/browser/assets/14946058/3d010955-9e15-4d61-bcfa-9ac514545eb8)
